### PR TITLE
Treat /0 as an invalid CIDR format

### DIFF
--- a/src/IPUtils.php
+++ b/src/IPUtils.php
@@ -158,8 +158,6 @@ class IPUtils
             if ($ipRange === null) {
                 return null;
             }
-        } else if ((int) substr($ipRange, $pos + 1) <= 0) {
-            return null;
         }
 
         $pos   = strpos($ipRange, '/');
@@ -172,7 +170,12 @@ class IPUtils
 
         $lowLen = strlen($low);
         $bits   = (int) substr($ipRange, $pos + 1);
-        $octet  = $bits ? (int) (($bits + 7) / 8) : 0;
+        
+        if ($bits < 0 || $bits * 8 > $lowLen) {
+            return null;
+        }
+            
+        $octet = (int) (($bits + 7) / 8);
 
         for ($i = $octet; $i < $lowLen; $i++) {
             $low[$i]  = chr(0);

--- a/src/IPUtils.php
+++ b/src/IPUtils.php
@@ -152,35 +152,39 @@ class IPUtils
      */
     public static function getIPRangeBounds($ipRange)
     {
-        if (strpos($ipRange, '/') === false) {
+        if (($pos = strrpos($ipRange, '/')) === false) {
             $ipRange = self::sanitizeIpRange($ipRange);
 
             if ($ipRange === null) {
                 return null;
             }
+        } else if ((int) substr($ipRange, $pos + 1) <= 0) {
+            return null;
         }
-        $pos = strpos($ipRange, '/');
 
-        $bits = substr($ipRange, $pos + 1);
+        $pos   = strpos($ipRange, '/');
         $range = substr($ipRange, 0, $pos);
-        $high = $low = @inet_pton($range);
+        $high  = $low = @inet_pton($range);
+
         if ($low === false) {
             return null;
         }
 
         $lowLen = strlen($low);
-        $i = $lowLen - 1;
-        $bits = $lowLen * 8 - $bits;
+        $bits   = (int) substr($ipRange, $pos + 1);
+        $octet  = $bits ? (int) (($bits + 7) / 8) : 0;
 
-        for ($n = (int)($bits / 8); $n > 0; $n--, $i--) {
-            $low[$i] = chr(0);
+        for ($i = $octet; $i < $lowLen; $i++) {
+            $low[$i]  = chr(0);
             $high[$i] = chr(255);
         }
 
-        $n = $bits % 8;
-        if ($n) {
-            $low[$i] = chr(ord($low[$i]) & ~((1 << $n) - 1));
-            $high[$i] = chr(ord($high[$i]) | ((1 << $n) - 1));
+        if (($n = $bits % 8)) {
+            $mask  = (1 << (8 - $n)) - 1;
+            $value = ord($low[--$octet]) & ~$mask;
+
+            $low[$octet]  = chr($value);
+            $high[$octet] = chr($value | $mask);
         }
 
         return array($low, $high);

--- a/tests/IPUtilsTest.php
+++ b/tests/IPUtilsTest.php
@@ -244,7 +244,7 @@ class IPUtilsTest extends \PHPUnit_Framework_TestCase
             array('', null),
             array('0', null),
             array('0.0.0.0/0', null),
-            array('192.168.255.255/0', null),
+            array('192.168.255.255/33', null),
             array('192.168.255.255/-1', null),
 
             // single IPv4
@@ -255,7 +255,7 @@ class IPUtilsTest extends \PHPUnit_Framework_TestCase
             array('192.168.*.*', array("\xc0\xa8\x00\x00", "\xc0\xa8\xff\xff")),
             array('192.*.*.*', array("\xc0\x00\x00\x00", "\xc0\xff\xff\xff")),
             array('*.*.*.*', array("\x00\x00\x00\x00", "\xff\xff\xff\xff")),
-
+ 
             // single IPv4 in expected CIDR notation
             array('192.168.1.1/24', array("\xc0\xa8\x01\x00", "\xc0\xa8\x01\xff")),
 
@@ -301,6 +301,7 @@ class IPUtilsTest extends \PHPUnit_Framework_TestCase
             array('192.168.255.255/3', array("\xc0\x00\x00\x00", "\xdf\xff\xff\xff")),
             array('192.168.255.255/2', array("\xc0\x00\x00\x00", "\xff\xff\xff\xff")),
             array('192.168.255.255/1', array("\x80\x00\x00\x00", "\xff\xff\xff\xff")),
+            array('0.0.0.0/0', array("\x00\x00\x00\x00", "\xff\xff\xff\xff")),
 
             // single IPv6
             array('::1', array("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01")),

--- a/tests/IPUtilsTest.php
+++ b/tests/IPUtilsTest.php
@@ -243,6 +243,9 @@ class IPUtilsTest extends \PHPUnit_Framework_TestCase
             array(null, null),
             array('', null),
             array('0', null),
+            array('0.0.0.0/0', null),
+            array('192.168.255.255/0', null),
+            array('192.168.255.255/-1', null),
 
             // single IPv4
             array('127.0.0.1', array("\x7f\x00\x00\x01", "\x7f\x00\x00\x01")),
@@ -282,6 +285,22 @@ class IPUtilsTest extends \PHPUnit_Framework_TestCase
             array('192.168.255.255/19', array("\xc0\xa8\xe0\x00", "\xc0\xa8\xff\xff")),
             array('192.168.255.255/18', array("\xc0\xa8\xc0\x00", "\xc0\xa8\xff\xff")),
             array('192.168.255.255/17', array("\xc0\xa8\x80\x00", "\xc0\xa8\xff\xff")),
+            array('192.168.255.255/16', array("\xc0\xa8\x00\x00", "\xc0\xa8\xff\xff")),
+            array('192.168.255.255/15', array("\xc0\xa8\x00\x00", "\xc0\xa9\xff\xff")),
+            array('192.168.255.255/14', array("\xc0\xa8\x00\x00", "\xc0\xab\xff\xff")),
+            array('192.168.255.255/13', array("\xc0\xa8\x00\x00", "\xc0\xaf\xff\xff")),
+            array('192.168.255.255/12', array("\xc0\xa0\x00\x00", "\xc0\xaf\xff\xff")),
+            array('192.168.255.255/11', array("\xc0\xa0\x00\x00", "\xc0\xbf\xff\xff")),
+            array('192.168.255.255/10', array("\xc0\x80\x00\x00", "\xc0\xbf\xff\xff")),
+            array('192.168.255.255/9', array("\xc0\x80\x00\x00", "\xc0\xff\xff\xff")),
+            array('192.168.255.255/8', array("\xc0\x00\x00\x00", "\xc0\xff\xff\xff")),
+            array('192.168.255.255/7', array("\xc0\x00\x00\x00", "\xc1\xff\xff\xff")),
+            array('192.168.255.255/6', array("\xc0\x00\x00\x00", "\xc3\xff\xff\xff")),
+            array('192.168.255.255/5', array("\xc0\x00\x00\x00", "\xc7\xff\xff\xff")),
+            array('192.168.255.255/4', array("\xc0\x00\x00\x00", "\xcf\xff\xff\xff")),
+            array('192.168.255.255/3', array("\xc0\x00\x00\x00", "\xdf\xff\xff\xff")),
+            array('192.168.255.255/2', array("\xc0\x00\x00\x00", "\xff\xff\xff\xff")),
+            array('192.168.255.255/1', array("\x80\x00\x00\x00", "\xff\xff\xff\xff")),
 
             // single IPv6
             array('::1', array("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01", "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01")),

--- a/tests/IPUtilsTest.php
+++ b/tests/IPUtilsTest.php
@@ -243,7 +243,6 @@ class IPUtilsTest extends \PHPUnit_Framework_TestCase
             array(null, null),
             array('', null),
             array('0', null),
-            array('0.0.0.0/0', null),
             array('192.168.255.255/33', null),
             array('192.168.255.255/-1', null),
 


### PR DESCRIPTION
WRT #4, I think the root cause analysis was incorrect, as code inspection suggested that edge case isn't possible.

In any case, I added more unit tests and running PHP 7.1.7, couldn't get `getIPRangeBounds` to reproduce the negative shift described by the OP.