### PR TITLE
validate hostname returned by gethostbyaddr()

### DIFF
--- a/src/IP.php
+++ b/src/IP.php
@@ -107,7 +107,7 @@ abstract class IP
 
         $host = strtolower(@gethostbyaddr($stringIp));
 
-        if ($host === '' || $host === $stringIp) {
+        if ($host === '' || $host === $stringIp || strlen($host) !== strspn($host, 'abcdefghijklmnopqrstuvwxyz01234567890-.')) {
             return null;
         }
 


### PR DESCRIPTION
For IDNs, the hostname is Punycode and would pass the `strspn()` validation used here.

So, part 2 would be a change to matomo-org/matomo to use Zend_Validate_Hostname.
