### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 install:
-  - composer install --dev
+  - composer install
+
+script:
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         }
     },
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "^4.8.36"
     }
 }

--- a/tests/IPTest.php
+++ b/tests/IPTest.php
@@ -10,11 +10,12 @@ namespace Tests\Piwik\Network;
 
 use Piwik\Network\IP;
 use Piwik\Network\IPUtils;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Piwik\Network\IP
  */
-class IPTest extends \PHPUnit_Framework_TestCase
+class IPTest extends TestCase
 {
     public function ipData()
     {
@@ -94,7 +95,7 @@ class IPTest extends \PHPUnit_Framework_TestCase
     public function testGetHostnameFailure()
     {
         $ip = IP::fromStringIP('0.1.2.3');
-        $this->assertSame(null, $ip->getHostname());
+        $this->assertNull($ip->getHostname());
     }
 
     public function getIpsInRangeData()

--- a/tests/IPUtilsTest.php
+++ b/tests/IPUtilsTest.php
@@ -9,11 +9,12 @@
 namespace Tests\Piwik\Network;
 
 use Piwik\Network\IPUtils;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers Piwik\Network\IPUtils
  */
-class IPUtilsTest extends \PHPUnit_Framework_TestCase
+class IPUtilsTest extends TestCase
 {
     public function getIPSanitizationData()
     {

--- a/tests/IPv4Test.php
+++ b/tests/IPv4Test.php
@@ -9,11 +9,12 @@
 namespace Tests\Piwik\Network;
 
 use Piwik\Network\IP;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Piwik\Network\IPv4
  */
-class IPv4Test extends \PHPUnit_Framework_TestCase
+class IPv4Test extends TestCase
 {
     public function getIPv4Data()
     {

--- a/tests/IPv6Test.php
+++ b/tests/IPv6Test.php
@@ -10,11 +10,12 @@ namespace Tests\Piwik\Network;
 
 use Piwik\Network\IP;
 use Piwik\Network\IPv6;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Piwik\Network\IPv6
  */
-class IPv6Test extends \PHPUnit_Framework_TestCase
+class IPv6Test extends TestCase
 {
     public function getIPv6Data()
     {


### PR DESCRIPTION
# Changed log
- Add `php-7.2` and `php-7.3` tests on Travis CI build.
- Removing `--dev` option because this option is deprecated on latest `composer` version.
The deprecated warning message is as follows:
```
You are using the deprecated option "dev". Dev packages are installed by default now.
```
- Using the `assertNull` to assert that the expected value is same as `null`.
- According to the `.travis.yml` setting, the minimal PHP version test is `5.4`.
Modify the `php` version requirement to be `>=5.4` inside `require` block on `composer.json`.