### PR TITLE
Rebrand from Piwik to Matomo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+./tests/ export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 install:
   - composer install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Piwik/Network
+# Matomo/Network
 
 Component providing Network tools.
 
@@ -12,7 +12,7 @@ With Composer:
 ```json
 {
     "require": {
-        "piwik/network": "*"
+        "matomo/network": "*"
     }
 }
 ```
@@ -21,7 +21,7 @@ With Composer:
 
 ### IP
 
-To manipulate an IP address, you can use the `Piwik\Network\IP` class:
+To manipulate an IP address, you can use the `Matomo\Network\IP` class:
 
 ```php
 $ip = IP::fromStringIP('127.0.0.1');
@@ -47,7 +47,7 @@ if ($ip->isInRange('192.168.*.*')) {}
 $ip->anonymize(2);
 ```
 
-The `Piwik\Network\IPUtils` class provides utility methods:
+The `Matomo\Network\IPUtils` class provides utility methods:
 
 ```php
 echo IPUtils::binaryToStringIP("\x7F\x00\x00\x01");

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Component providing Network tools.
 
 [![Build Status](https://travis-ci.org/matomo-org/component-network.svg?branch=master)](https://travis-ci.org/matomo-org/component-network)
-[![Coverage Status](https://coveralls.io/repos/matomo-org/component-network/badge.png?branch=master)](https://coveralls.io/r/matomo-org/component-network?branch=master)
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,15 @@
 {
-    "name": "piwik/network",
+    "name": "matomo/network",
     "type": "library",
     "license": "LGPL-3.0",
     "autoload": {
         "psr-4": {
-            "Piwik\\Network\\": "src/"
+            "Matomo\\Network\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\Piwik\\Network\\": "tests/"
+            "Tests\\Matomo\\Network\\": "tests/"
         }
     },
     "require": {

--- a/src/IP.php
+++ b/src/IP.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Network;
+namespace Matomo\Network;
 
 /**
  * IP address.

--- a/src/IPUtils.php
+++ b/src/IPUtils.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Network;
+namespace Matomo\Network;
 
 /**
  * IP address utilities (for both IPv4 and IPv6).

--- a/src/IPv4.php
+++ b/src/IPv4.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Network;
+namespace Matomo\Network;
 
 /**
  * IP v4 address.

--- a/src/IPv6.php
+++ b/src/IPv6.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Piwik\Network;
+namespace Matomo\Network;
 
 /**
  * IP v6 address.

--- a/tests/IPTest.php
+++ b/tests/IPTest.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Network;
+namespace Tests\Matomo\Network;
 
-use Piwik\Network\IP;
-use Piwik\Network\IPUtils;
+use Matomo\Network\IP;
+use Matomo\Network\IPUtils;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Piwik\Network\IP
+ * @covers \Matomo\Network\IP
  */
 class IPTest extends TestCase
 {
@@ -50,7 +50,7 @@ class IPTest extends TestCase
     {
         $ip = IP::fromBinaryIP($binary);
 
-        $this->assertInstanceOf('Piwik\Network\\' . $class, $ip);
+        $this->assertInstanceOf('Matomo\Network\\' . $class, $ip);
 
         $this->assertEquals($binary, $ip->toBinary());
         $this->assertEquals($str, $ip->toString());
@@ -64,7 +64,7 @@ class IPTest extends TestCase
     {
         $ip = IP::fromBinaryIP($ipAddress);
 
-        $this->assertInstanceOf('Piwik\Network\\IPv4', $ip);
+        $this->assertInstanceOf('Matomo\Network\\IPv4', $ip);
 
         $this->assertEquals($expectedBinary, $ip->toBinary());
         $this->assertEquals($expectedStr, $ip->toString());
@@ -90,7 +90,7 @@ class IPTest extends TestCase
     {
         $ip = IP::fromStringIP($ipAddress);
 
-        $this->assertInstanceOf('Piwik\Network\\IPv4', $ip);
+        $this->assertInstanceOf('Matomo\Network\\IPv4', $ip);
 
         $this->assertEquals($expectedBinary, $ip->toBinary());
         $this->assertEquals($expectedStr, $ip->toString());

--- a/tests/IPUtilsTest.php
+++ b/tests/IPUtilsTest.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Network;
+namespace Tests\Matomo\Network;
 
-use Piwik\Network\IPUtils;
+use Matomo\Network\IPUtils;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Piwik\Network\IPUtils
+ * @covers Matomo\Network\IPUtils
  */
 class IPUtilsTest extends TestCase
 {

--- a/tests/IPv4Test.php
+++ b/tests/IPv4Test.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Network;
+namespace Tests\Matomo\Network;
 
-use Piwik\Network\IP;
+use Matomo\Network\IP;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Piwik\Network\IPv4
+ * @covers \Matomo\Network\IPv4
  */
 class IPv4Test extends TestCase
 {
@@ -32,7 +32,7 @@ class IPv4Test extends TestCase
     {
         $ip = IP::fromStringIP($stringIp);
 
-        $this->assertInstanceOf('Piwik\Network\IPv4', $ip);
+        $this->assertInstanceOf('Matomo\Network\IPv4', $ip);
 
         $this->assertEquals($expected, $ip->toIPv4String(), $stringIp);
     }
@@ -64,7 +64,7 @@ class IPv4Test extends TestCase
     {
         $ip = IP::fromStringIP($ipString);
 
-        $this->assertInstanceOf('Piwik\Network\IPv4', $ip);
+        $this->assertInstanceOf('Matomo\Network\IPv4', $ip);
 
         // each IP is tested with 0 to 4 octets masked
         for ($byteCount = 0; $byteCount <= 4; $byteCount++) {

--- a/tests/IPv6Test.php
+++ b/tests/IPv6Test.php
@@ -1,19 +1,19 @@
 <?php
 /**
- * Piwik - free/libre analytics platform
+ * Matomo - free/libre analytics platform
  *
- * @link http://piwik.org
+ * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL v3 or later
  */
 
-namespace Tests\Piwik\Network;
+namespace Tests\Matomo\Network;
 
-use Piwik\Network\IP;
-use Piwik\Network\IPv6;
+use Matomo\Network\IP;
+use Matomo\Network\IPv6;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \Piwik\Network\IPv6
+ * @covers \Matomo\Network\IPv6
  */
 class IPv6Test extends TestCase
 {
@@ -32,7 +32,7 @@ class IPv6Test extends TestCase
     {
         $ip = IP::fromStringIP($stringIp);
 
-        $this->assertInstanceOf('Piwik\Network\IPv6', $ip);
+        $this->assertInstanceOf('Matomo\Network\IPv6', $ip);
 
         $this->assertEquals($expected, $ip->toIPv4String(), $stringIp);
     }
@@ -88,7 +88,7 @@ class IPv6Test extends TestCase
     {
         $ip = IP::fromStringIP($ipString);
 
-        $this->assertInstanceOf('Piwik\Network\IPv6', $ip);
+        $this->assertInstanceOf('Matomo\Network\IPv6', $ip);
 
         // each IP is tested with 0 to 4 octets masked
         for ($byteCount = 0; $byteCount < 4; $byteCount++) {
@@ -125,7 +125,7 @@ class IPv6Test extends TestCase
     {
         $ip = IP::fromStringIP('::ffff:' . $ipString);
 
-        $this->assertInstanceOf('Piwik\Network\IPv6', $ip);
+        $this->assertInstanceOf('Matomo\Network\IPv6', $ip);
 
         // mask IPv4 mapped addresses
         for ($byteCount = 0; $byteCount <= 4; $byteCount++) {


### PR DESCRIPTION
Once merged, it should be released as version 2.0 and republished on packagist.
Old package needs to be marked as `Abandoned`. Don't have enough rights or credentials to do that...